### PR TITLE
Add navigation bar spec for merchant user

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,8 +21,13 @@
 
       <% elsif current_user.default? %>
         <%= link_to "Cart: #{cart.total_items}", "/cart" %>
-        <%= link_to "Logout", "/logout"%>
+        <%= link_to "Logout", "/logout" %>
         <%= link_to "User Profile", "/default_user/profile"%>
+
+      <% elsif current_user.merchant? %>
+        <%= link_to "Cart: #{cart.total_items}", "/cart" %>
+        <%= link_to "Logout", "/logout"%>
+        <%= link_to "Merchant Dashboard", "/merchant/dashboard"%>
 
       <% elsif current_user.admin? %>
         <%= link_to "Logout", "/logout"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,22 +25,13 @@ Rails.application.routes.draw do
   post "/register", to: 'users#create'
 
   post "/users", to: "users#create"
-
+  
   get "/login", to: 'sessions#new'
-  post "/login", to: 'sessions#create'
+  post '/login', to: 'sessions#create'
 
   namespace :default_user do
     get "/profile", to: 'profile#index'
   end
-
-  namespace :merchant do
-    get '/dashboard', to: 'dashboard#index'
-  end
-
-  get "/profile", to: 'profile#index'
-
-  get "/login", to: 'sessions#new'
-  post '/login', to: 'sessions#create'
 
   namespace :merchant do
     get '/dashboard', to: 'dashboard#index'

--- a/spec/features/admin/navigation_bar_spec.rb
+++ b/spec/features/admin/navigation_bar_spec.rb
@@ -21,8 +21,10 @@ RSpec.describe 'As an admin user' do
                 expect(page).to have_link("Home")
                 expect(page).to have_link("All Merchants")
                 expect(page).to have_link("All Items")
+                expect(page).to have_link("Dashboard")
                 expect(page).to_not have_link("Login")
                 expect(page).to_not have_link("Register")
+                expect(page).to_not have_link("Cart: 0")
             end
         end
     end

--- a/spec/features/merchant_user/navigation_bar_spec.rb
+++ b/spec/features/merchant_user/navigation_bar_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe 'As an merchant employee user' do
+    describe 'in the navigation bar' do
+        it 'I see links to home page, items index page, merchants index page, dashboard, logout, and profile page' do
+
+            employee = User.create(name: "Employee user",
+                                       address: "99 Working Hard Lane",
+                                       city: "Los Angeles",
+                                       state: "California",
+                                       zip: "90210",
+                                       email: "employee_email@gmail.com",
+                                       password: "employee_password",
+                                       role: 1) 
+                                
+            allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(employee)  
+
+            visit "/merchant/dashboard"
+
+            within 'nav' do
+                expect(page).to have_link("Home")
+                expect(page).to have_link("All Merchants")
+                expect(page).to have_link("All Items")
+                expect(page).to have_link("Cart: 0")
+                expect(page).to have_link("Merchant Dashboard")
+                expect(page).to_not have_link("Login")
+                expect(page).to_not have_link("Register")
+            end
+        end
+    end
+end


### PR DESCRIPTION
This finishes the functionality for navigation bar links specific to each type of user.