### PR TITLE
User story 30

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,7 +13,7 @@
  */
  // Custom bootstrap variables must be set or imported *before* bootstrap.
  @import "bootstrap";
- 
+
  body {
  background-color: white;
  }
@@ -151,6 +151,7 @@ td, th {
   border: 1px solid #f2f2f2;
   text-align: center;
   padding: 8px;
+  width: 60%;
 }
 
 tr:nth-child(even) {

--- a/app/controllers/default_user/orders_controller.rb
+++ b/app/controllers/default_user/orders_controller.rb
@@ -7,4 +7,9 @@ class DefaultUser::OrdersController < DefaultUser::BaseController
   def show
     @order =  current_user.orders.find(params[:id])
   end
+
+  def update
+    flash[:notice] = "Your Order Has Been Cancelled"
+    redirect_to default_user_profile_path
+  end
 end

--- a/app/controllers/default_user/orders_controller.rb
+++ b/app/controllers/default_user/orders_controller.rb
@@ -5,11 +5,14 @@ class DefaultUser::OrdersController < DefaultUser::BaseController
   end
 
   def show
-    @order =  current_user.orders.find(params[:id])
+    @order = current_user.orders.find(params[:id])
   end
 
   def update
+    order = Order.find(params[:id])
+    order.cancel
     flash[:notice] = "Your Order Has Been Cancelled"
     redirect_to default_user_profile_path
   end
+
 end

--- a/app/controllers/default_user/orders_controller.rb
+++ b/app/controllers/default_user/orders_controller.rb
@@ -14,5 +14,4 @@ class DefaultUser::OrdersController < DefaultUser::BaseController
     flash[:notice] = "Your Order Has Been Cancelled"
     redirect_to default_user_profile_path
   end
-
 end

--- a/app/controllers/default_user/orders_controller.rb
+++ b/app/controllers/default_user/orders_controller.rb
@@ -3,4 +3,8 @@ class DefaultUser::OrdersController < DefaultUser::BaseController
   def index
     @orders = current_user.orders
   end
+
+  def show
+    @order =  current_user.orders.find(params[:id])
+  end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -25,8 +25,7 @@ class OrdersController <ApplicationController
       render :new
     end
   end
-
-
+  
   private
 
   def order_params

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -4,6 +4,8 @@ class ItemOrder <ApplicationRecord
   belongs_to :item
   belongs_to :order
 
+  enum status: %w(unfulfilled fulfilled)
+
   def subtotal
     price * quantity
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -14,5 +14,10 @@ class Order <ApplicationRecord
 
   def cancel
     update(status: "Cancelled")
+
+    item_orders.each do |item_order|
+      item_order.update(status: 0)
+      item_order.item.update(inventory: item_order.item.inventory + item_order.quantity)
+    end
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -11,4 +11,8 @@ class Order <ApplicationRecord
   def total_quantity
     item_orders.sum(:quantity)
   end
+
+  def cancel
+    update(status: "Cancelled")
+  end
 end

--- a/app/views/default_user/orders/index.html.erb
+++ b/app/views/default_user/orders/index.html.erb
@@ -4,6 +4,7 @@
 <% @orders.each do |order| %>
   <section class="orders-<%= order.id %>">
     <b> Order Number: <%= link_to "#{order.id}", "/default_user/profile/orders/#{order.id}" %></b>
+    <p> Status: <%= order.status %></p>
     <p> Order Placed: <%= order.created_at.to_formatted_s(:long) %></p>
     <p> Last Updated: <%= order.updated_at.to_formatted_s(:long) %></p>
     <p> Total Quantity: <%= order.total_quantity %></p>

--- a/app/views/default_user/orders/index.html.erb
+++ b/app/views/default_user/orders/index.html.erb
@@ -1,4 +1,5 @@
-<h1>History of Your Orders</h1>
+
+<h1>Order History</h1>
 
 <% @orders.each do |order| %>
   <section class="orders-<%= order.id %>">

--- a/app/views/default_user/orders/show.html.erb
+++ b/app/views/default_user/orders/show.html.erb
@@ -1,0 +1,39 @@
+<h1>Order Number: <%= @order.id %></h1>
+
+<p> Order Placed: <%= @order.created_at.to_formatted_s(:long) %></p>
+<p> Last Updated: <%= @order.updated_at.to_formatted_s(:long) %></p>
+<p> Status: "pending" </p>
+
+<h3 align = "center"> Order Summary </h3>
+<center>
+  <table>
+    <tr>
+      <th>Thumbnail</th>
+      <th>Name</th>
+      <th>Description</th>
+      <th>Price</th>
+      <th>Quantity</th>
+      <th>Subtotal</th>
+    </tr>
+  <% @order.item_orders.each do |item_order|%>
+    <tr>
+    <section id = "item-<%=item_order.item_id%>">
+        <td><p><img src= <%= item_order.item.image %>></td>
+        <td><p><%= item_order.item.name %></p></td>
+        <td><p><%= item_order.item.description %></p></td>
+        <td><p><%= number_to_currency(item_order.price)%></p></td>
+        <td><p><%= item_order.quantity%></p></td>
+        <td><p><%= number_to_currency(item_order.subtotal)%></p></td>
+      </section>
+    </tr>
+  <% end %>
+</table>
+
+<table>
+  <tr>
+    <th>Total Quantity</th>
+    <th>Grand Total</th>
+  <tr>
+    <td><p><%= @order.total_quantity %></p></td>
+    <td><p><%= number_to_currency(@order.grandtotal) %></p></td>
+</table>

--- a/app/views/default_user/orders/show.html.erb
+++ b/app/views/default_user/orders/show.html.erb
@@ -16,6 +16,7 @@
       <th>Price</th>
       <th>Quantity</th>
       <th>Subtotal</th>
+      <th>Status</th>
     </tr>
   <% @order.item_orders.each do |item_order|%>
     <tr>
@@ -26,6 +27,7 @@
         <td><p><%= number_to_currency(item_order.price)%></p></td>
         <td><p><%= item_order.quantity%></p></td>
         <td><p><%= number_to_currency(item_order.subtotal)%></p></td>
+        <td><p><%= item_order.status%></p></td>
       </section>
     </tr>
   <% end %>

--- a/app/views/default_user/orders/show.html.erb
+++ b/app/views/default_user/orders/show.html.erb
@@ -2,7 +2,9 @@
 
 <p> Order Placed: <%= @order.created_at.to_formatted_s(:long) %></p>
 <p> Last Updated: <%= @order.updated_at.to_formatted_s(:long) %></p>
-<p> Status: "pending" </p>
+<p> Status: <%= @order.status %></p>
+
+<button><%= link_to "Cancel Order", default_user_profile_path, method: :put %></button>
 
 <h3 align = "center"> Order Summary </h3>
 <center>

--- a/app/views/default_user/orders/show.html.erb
+++ b/app/views/default_user/orders/show.html.erb
@@ -3,8 +3,7 @@
 <p> Order Placed: <%= @order.created_at.to_formatted_s(:long) %></p>
 <p> Last Updated: <%= @order.updated_at.to_formatted_s(:long) %></p>
 <p> Status: <%= @order.status %></p>
-
-<button><%= link_to "Cancel Order", default_user_profile_path, method: :put %></button>
+<p><%= link_to "Cancel Order", "/default_user/profile/orders/#{@order.id}", method: :patch %></p>
 
 <h3 align = "center"> Order Summary </h3>
 <center>

--- a/app/views/default_user/orders/show.html.erb
+++ b/app/views/default_user/orders/show.html.erb
@@ -3,7 +3,8 @@
 <p> Order Placed: <%= @order.created_at.to_formatted_s(:long) %></p>
 <p> Last Updated: <%= @order.updated_at.to_formatted_s(:long) %></p>
 <p> Status: <%= @order.status %></p>
-<p><%= link_to "Cancel Order", "/default_user/profile/orders/#{@order.id}", method: :patch %></p>
+
+<p><%= link_to "Cancel Order", "/default_user/profile/orders/#{@order.id}", method: :patch unless @order.status == "Cancelled"%></p>
 
 <h3 align = "center"> Order Summary </h3>
 <center>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   delete "/cart", to: "cart#empty"
   delete "/cart/:item_id", to: "cart#remove_item"
 
-  resources :orders, only: [:new, :create, :show]
+  resources :orders, only: [:new, :create, :show, :update]
 
   get "/register", to: "users#new"
   post "/register", to: 'users#create'
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
     patch "/profile", to: 'profile#update'
     get "/profile/orders", to: 'orders#index'
     get "/profile/orders/:id", to: 'orders#show'
-    put "/profile", to: 'orders#update'
+    patch "/profile/orders/:id", to: 'orders#update'
   end
 
   namespace :merchant do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     get "/profile/edit", to: 'profile#edit'
     patch "/profile", to: 'profile#update'
     get "/profile/orders", to: 'orders#index'
+    get "/profile/orders/:id", to: 'orders#show'
   end
 
   namespace :merchant do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
     patch "/profile", to: 'profile#update'
     get "/profile/orders", to: 'orders#index'
     get "/profile/orders/:id", to: 'orders#show'
+    put "/profile", to: 'orders#update'
   end
 
   namespace :merchant do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   delete "/cart", to: "cart#empty"
   delete "/cart/:item_id", to: "cart#remove_item"
 
-  resources :orders, only: [:new, :create, :show, :update]
+  resources :orders, only: [:new, :create, :show]
 
   get "/register", to: "users#new"
   post "/register", to: 'users#create'

--- a/db/migrate/20200531202757_add_status_to_orders.rb
+++ b/db/migrate/20200531202757_add_status_to_orders.rb
@@ -1,0 +1,5 @@
+class AddStatusToOrders < ActiveRecord::Migration[5.1]
+  def change
+    add_column :orders, :status, :string, default: "pending"
+  end
+end

--- a/db/migrate/20200531211025_add_statusto_item_orders.rb
+++ b/db/migrate/20200531211025_add_statusto_item_orders.rb
@@ -1,0 +1,5 @@
+class AddStatustoItemOrders < ActiveRecord::Migration[5.1]
+  def change
+    add_column :item_orders, :status, :integer, default: 0
+  end
+end

--- a/db/migrate/20200531213550_remove_default_in_orders.rb
+++ b/db/migrate/20200531213550_remove_default_in_orders.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultInOrders < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :orders, :status
+  end
+end

--- a/db/migrate/20200531214001_add_status_as_integer_to_orders.rb
+++ b/db/migrate/20200531214001_add_status_as_integer_to_orders.rb
@@ -1,0 +1,5 @@
+class AddStatusAsIntegerToOrders < ActiveRecord::Migration[5.1]
+  def change
+    add_column :orders, :status, :integer, default: 0
+  end
+end

--- a/db/migrate/20200601004903_change_status_to_string.rb
+++ b/db/migrate/20200601004903_change_status_to_string.rb
@@ -1,0 +1,5 @@
+class ChangeStatusToString < ActiveRecord::Migration[5.1]
+  def change
+    change_column :orders, :status, :string, default: "Pending"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200531013413) do
+ActiveRecord::Schema.define(version: 20200531202757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 20200531013413) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.string "status", default: "pending"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 20200530030701) do
-
+ActiveRecord::Schema.define(version: 20200531013413) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200531202757) do
+ActiveRecord::Schema.define(version: 20200531211025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20200531202757) do
     t.integer "quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
     t.index ["item_id"], name: "index_item_orders_on_item_id"
     t.index ["order_id"], name: "index_item_orders_on_order_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200531211025) do
+ActiveRecord::Schema.define(version: 20200601004903) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 20200531211025) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
-    t.string "status", default: "pending"
+    t.string "status", default: "Pending"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 

--- a/spec/features/default_user/orders/cancel_spec.rb
+++ b/spec/features/default_user/orders/cancel_spec.rb
@@ -13,39 +13,31 @@ RSpec.describe "Cancelling An Order" do
     ItemOrder.create(item: @cardboard, price: @cardboard.price, quantity: 20, order_id: @order.id)
   end
 
-  it "I can cancel my order and it will display a flash message" do
+  it "I can cancel an order and the statuses of my order and item orders are changed" do
 
     visit "/default_user/profile/orders/#{@order.id}"
+
+    expect(page).to have_content("Status: Pending")
 
     click_link "Cancel Order"
 
     expect(page).to have_content("Your Order Has Been Cancelled")
     expect(current_path).to eq(default_user_profile_path)
-  end
-
-  it "when I cancel an order, the status of my items and order are changed" do
-
-    visit "/default_user/profile/orders/#{@order.id}"
-
-    expect(page).to have_content("Status: pending")
-    expect(page).to have_content("fulfilled")
-
-    click_link "Cancel Order"
 
     visit "/default_user/profile/orders/#{@order.id}"
 
     expect(page).to have_content("unfulfilled")
-    expect(page).to have_content("Status: cancelled")
+    expect(page).to have_content("Status: Cancelled")
 
     visit default_user_profile_orders_path
 
-    expect(page).to have_content("Status: cancelled")
+    expect(page).to have_content("Status: Cancelled")
   end
 end
 
 
 # User Story 30, User cancels an order
-#
+
 # As a registered user
 # When I visit an order's show page
 # I see a button or link to cancel the order

--- a/spec/features/default_user/orders/cancel_spec.rb
+++ b/spec/features/default_user/orders/cancel_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe "Cancelling An Order" do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
 
     @order = Order.create(name: 'Natasha Romanoff', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033, user_id: @user.id)
-    ItemOrder.create(item: @cardboard, price: @cardboard.price, quantity: 20, order_id: @order.id)
+    ItemOrder.create(item: @cardboard, price: @cardboard.price, quantity: 2, order_id: @order.id)
   end
 
-  it "I can cancel an order and the statuses of my order and item orders are changed" do
+  it "I can cancel an order and it will update the statuses of my order and item orders" do
 
     visit "/default_user/profile/orders/#{@order.id}"
 
@@ -33,18 +33,15 @@ RSpec.describe "Cancelling An Order" do
 
     expect(page).to have_content("Status: Cancelled")
   end
+
+  it "can update inventory when order is cancelled" do
+
+    visit "/default_user/profile/orders/#{@order.id}"
+
+    expect(@shop.items.first.inventory).to eq(20)
+
+    click_link "Cancel Order"
+
+    expect(@shop.items.first.inventory).to eq(22)
+  end
 end
-
-
-# User Story 30, User cancels an order
-
-# As a registered user
-# When I visit an order's show page
-# I see a button or link to cancel the order
-# When I click the cancel button for an order, the following happens: <=
-# - Each row in the "order items" table is given a status of "unfulfilled"
-# - The order itself is given a status of "cancelled"
-# - Any item quantities in the order that were previously fulfilled have their quantities returned to their respective merchant's inventory for that item.
-# - I am returned to my profile page
-# - I see a flash message telling me the order is now cancelled <=
-# - And I see that this order now has an updated status of "cancelled" <=

--- a/spec/features/default_user/orders/index_spec.rb
+++ b/spec/features/default_user/orders/index_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Default User's Profile Orders Page" do
          expect(page).to have_link("#{order1.id}")
          expect(page).to have_content("Order Placed: #{create1}")
          expect(page).to have_content("Last Updated: #{update1}")
-         # expect(page).to have_content("Status:#{order1.status}")
+         expect(page).to have_content("Status: #{order1.status}")
          expect(page).to have_content("Total Quantity: 2")
          expect(page).to have_content("Grand Total: $200")
          expect(page).to_not have_content("Order Number: #{order2.id}")

--- a/spec/features/default_user/orders/index_spec.rb
+++ b/spec/features/default_user/orders/index_spec.rb
@@ -32,13 +32,6 @@ RSpec.describe "Default User's Profile Orders Page" do
      end
 
      it "I can see a list of every order I've made" do
-       #The show page template for an order can be shared between users, merchants and admins to DRY up our presentation logic. They will operate through separate controllers, though.
-
-       #created_at(date order was made)
-       #updated_at(date order was last updated)
-       #status made in user story 26(so will ignore for now)
-       #total_quantity method in orders controller [X]
-       #grand_total method already in orders [X]
        shop = Merchant.create(name: "K-Pop Black Market", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
        cardboard = shop.items.create(name: "EXO Kai Cardboard", description: "Just a cutout", price: 100, image: "https://images-na.jpg", inventory: 20)
 
@@ -64,7 +57,7 @@ RSpec.describe "Default User's Profile Orders Page" do
          # expect(page).to have_content("Status:#{order1.status}")
          expect(page).to have_content("Total Quantity: 2")
          expect(page).to have_content("Grand Total: $200")
-         expect(page).to_not have_content(order2.id)
+         expect(page).to_not have_content("Order Number: #{order2.id}")
        end
 
        within ".orders-#{order2.id}" do
@@ -72,20 +65,7 @@ RSpec.describe "Default User's Profile Orders Page" do
          expect(page).to have_link("#{order2.id}")
          expect(page).to have_content("Total Quantity: 3")
          expect(page).to have_content("Grand Total: $300")
-         expect(page).to_not have_content(order1.id)
+         expect(page).to_not have_content("Order Number: #{order1.id}")
        end
      end
-   end
 end
-
-# User Story 28, User Profile displays Orders
-
-# As a registered user
-# When I visit my Profile Orders page, "/profile/orders"
-# I see every order I've made, which includes the following information:
-# - the ID of the order, which is a link to the order show page
-# - the date the order was made
-# - the date the order was last updated
-# - the current status of the order
-# - the total quantity of items in the order
-# - the grand total of all items for that order

--- a/spec/features/default_user/orders/show_spec.rb
+++ b/spec/features/default_user/orders/show_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Order Show Page" do
       expect(page).to have_content("Order Number: #{order.id}")
       expect(page).to have_content("Order Placed: #{create1}")
       expect(page).to have_content("Last Updated: #{update1}")
-      # expect(page).to have_content("Status:#{order1.status}")
+      expect(page).to have_content("Status: #{order.status}")
       expect(page).to have_content("2")
       expect(page).to have_content("$2,090.00")
       expect(page).to have_content("EXO Kai Cardboard")

--- a/spec/features/default_user/orders/show_spec.rb
+++ b/spec/features/default_user/orders/show_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe "Order Show Page" do
       expect(page).to have_content("Just a cutout")
       expect(page).to have_content("$100.00")
       expect(page).to have_content("20")
-
     end
   end
 end

--- a/spec/features/default_user/orders/show_spec.rb
+++ b/spec/features/default_user/orders/show_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "Order Show Page" do
+  describe "When I click on an order number from my order index" do
+    it "can take me to an order show page and display the order's informaton" do
+      shop = Merchant.create(name: "K-Pop Black Market", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      cardboard = shop.items.create(name: "EXO Kai Cardboard", description: "Just a cutout", price: 100, image: "https://images-na.jpg", inventory: 20)
+      album = shop.items.create(name: "SJ TimeSlip", description: "Album", price: 30, image: "https://images-na.jpg", inventory: 30)
+
+      user = User.create(name: "Natasha Romanoff", address: "890 Fifth Avenue", city: "Manhattan", state: "New York", zip: "10010", email: "spiderqueen@hotmail.com", password: "arrow", role: 0)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      order = Order.create(name: 'Natasha Romanoff', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033, user_id: user.id)
+      create1 = order.created_at.to_formatted_s(:long)
+      update1 = order.updated_at.to_formatted_s(:long)
+
+      ItemOrder.create(item: cardboard, price: cardboard.price, quantity: 20, order_id: order.id)
+      ItemOrder.create(item: album, price: album.price, quantity: 3, order_id: order.id)
+
+      visit default_user_profile_orders_path
+
+      click_on "#{order.id}"
+
+      expect(current_path).to eq("/default_user/profile/orders/#{order.id}")
+
+      expect(page).to have_content("Order Number: #{order.id}")
+      expect(page).to have_content("Order Placed: #{create1}")
+      expect(page).to have_content("Last Updated: #{update1}")
+      # expect(page).to have_content("Status:#{order1.status}")
+      expect(page).to have_content("2")
+      expect(page).to have_content("$2,090.00")
+      expect(page).to have_content("EXO Kai Cardboard")
+      expect(page).to have_content("Just a cutout")
+      expect(page).to have_content("$100.00")
+      expect(page).to have_content("20")
+
+    end
+  end
+end

--- a/spec/features/default_user/orders/show_spec.rb
+++ b/spec/features/default_user/orders/show_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "Order Show Page" do
       expect(page).to have_content("Last Updated: #{update1}")
       expect(page).to have_content("Status: #{order.status}")
       expect(page).to have_content("2")
+      expect(page).to have_content("unfulfilled")
       expect(page).to have_content("$2,090.00")
       expect(page).to have_content("EXO Kai Cardboard")
       expect(page).to have_content("Just a cutout")

--- a/spec/features/default_user/orders/update_spec.rb
+++ b/spec/features/default_user/orders/update_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "Cancelling An Order" do
+  before :each do
+    @shop = Merchant.create(name: "K-Pop Black Market", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    @cardboard = @shop.items.create(name: "EXO Kai Cardboard", description: "Just a cutout", price: 100, image: "https://images-na.jpg", inventory: 20)
+
+    @user = User.create(name: "Natasha Romanoff", address: "890 Fifth Avenue", city: "Manhattan", state: "New York", zip: "10010", email: "spiderqueen@hotmail.com", password: "arrow", role: 0)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+    @order = Order.create(name: 'Natasha Romanoff', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033, user_id: @user.id)
+    ItemOrder.create(item: @cardboard, price: @cardboard.price, quantity: 20, order_id: @order.id)
+  end
+
+  it "I can cancel my order and it will display a flash message" do
+
+    visit "/default_user/profile/orders/#{@order.id}"
+
+    click_on "Cancel Order"
+
+    expect(current_path).to eq(default_user_profile_path)
+    expect(page).to have_content("Your Order Has Been Cancelled")
+  end
+end
+
+
+
+
+# User Story 30, User cancels an order
+#
+# As a registered user
+# When I visit an order's show page
+# I see a button or link to cancel the order
+# When I click the cancel button for an order, the following happens: <=
+# - Each row in the "order items" table is given a status of "unfulfilled"
+# - The order itself is given a status of "cancelled"
+# - Any item quantities in the order that were previously fulfilled have their quantities returned to their respective merchant's inventory for that item.
+# - I am returned to my profile page
+# - I see a flash message telling me the order is now cancelled <=
+# - And I see that this order now has an updated status of "cancelled" <=

--- a/spec/features/default_user/orders/update_spec.rb
+++ b/spec/features/default_user/orders/update_spec.rb
@@ -23,10 +23,25 @@ RSpec.describe "Cancelling An Order" do
     expect(current_path).to eq(default_user_profile_path)
   end
 
-  
+  it "when I cancel an order, the status of my items and order are changed" do
+
+    visit "/default_user/profile/orders/#{@order.id}"
+
+    expect(page).to have_content("Status: pending")
+    expect(page).to have_content("fulfilled")
+
+    click_link "Cancel Order"
+
+    visit "/default_user/profile/orders/#{@order.id}"
+
+    expect(page).to have_content("unfulfilled")
+    expect(page).to have_content("Status: cancelled")
+
+    visit default_user_profile_orders_path
+
+    expect(page).to have_content("Status: cancelled")
+  end
 end
-
-
 
 
 # User Story 30, User cancels an order

--- a/spec/features/default_user/orders/update_spec.rb
+++ b/spec/features/default_user/orders/update_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe "Cancelling An Order" do
   it "I can cancel my order and it will display a flash message" do
 
     visit "/default_user/profile/orders/#{@order.id}"
+    
+    click_link "Cancel Order"
 
-    click_on "Cancel Order"
-
-    expect(current_path).to eq(default_user_profile_path)
     expect(page).to have_content("Your Order Has Been Cancelled")
+    expect(current_path).to eq(default_user_profile_path)
   end
 end
 

--- a/spec/features/default_user/orders/update_spec.rb
+++ b/spec/features/default_user/orders/update_spec.rb
@@ -16,12 +16,14 @@ RSpec.describe "Cancelling An Order" do
   it "I can cancel my order and it will display a flash message" do
 
     visit "/default_user/profile/orders/#{@order.id}"
-    
+
     click_link "Cancel Order"
 
     expect(page).to have_content("Your Order Has Been Cancelled")
     expect(current_path).to eq(default_user_profile_path)
   end
+
+  
 end
 
 

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Items Index Page" do
     it "the user can click on the item image and it goes to the show page" do
       visit "/items"
 
-      page.first(:xpath, "//a[contains(@href,'items/#{@dog_bone.id}')]")
+      page.first(:xpath, "//a[contains(@href,'items/#{@dog_bone.id}')]").click
       expect(current_path).to eq("/items/#{@dog_bone.id}")
     end
   end

--- a/spec/features/users/edit_profile_spec.rb
+++ b/spec/features/users/edit_profile_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "User can edit their profile data" do
       expect(page).to have_content(default_user.email)
       expect(page).to_not have_content(default_user.password)
   end
-  
+
   it "gives errors if fields not entered" do
     default_user = User.create(name: "Natasha Romanoff",
       address: "890 Fifth Avenue",
@@ -64,7 +64,7 @@ RSpec.describe "User can edit their profile data" do
       expect(page).to have_content("Name can't be blank")
 
     end
-  
+
     it "user can't update profile with an existing email" do
       default_user = User.create(name: "Natasha Romanoff",
         address: "890 Fifth Avenue",
@@ -82,9 +82,11 @@ RSpec.describe "User can edit their profile data" do
         email: "spiderqueen@hotmail.com",
         password: "tony",
         role: 0)
-      
+
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(default_user)
-      
+
+        visit default_user_profile_path
+        
         click_on("Edit Profile")
         fill_in "Email", with: "spiderqueen@hotmail.com"
         click_on("Submit update")

--- a/spec/models/item_orders_spec.rb
+++ b/spec/models/item_orders_spec.rb
@@ -25,4 +25,19 @@ describe ItemOrder, type: :model do
     end
   end
 
+  describe 'status' do
+    it "can assign an order is unfulfilled" do
+      shop = Merchant.create(name: "K-Pop Black Market", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      cardboard = shop.items.create(name: "EXO Kai Cardboard", description: "Just a cutout", price: 100, image: "https://images-na.jpg", inventory: 20)
+
+      user = User.create(name: "Natasha Romanoff", address: "890 Fifth Avenue", city: "Manhattan", state: "New York", zip: "10010", email: "spiderqueen@hotmail.com", password: "arrow", role: 0)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      order = Order.create(name: 'Natasha Romanoff', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033, user_id: user.id)
+      item_order = ItemOrder.create(item: cardboard, price: cardboard.price, quantity: 20, order_id: order.id)
+
+      expect(item_order.status).to eq("unfulfilled")
+    end
+  end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -25,7 +25,7 @@ describe Order, type: :model do
 
       @user = User.create(name: "Natasha Romanoff", address: "890 Fifth Avenue", city: "Manhattan", state: "New York", zip: "10010", email: "spiderqueen@hotmail.com", password: "arrow", role: 0)
       @order_1 = Order.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033, user_id: @user.id)
-      @order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
+      @item_order1 = @order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
       @order_1.item_orders.create!(item: @pull_toy, price: @pull_toy.price, quantity: 3)
     end
 
@@ -43,6 +43,7 @@ describe Order, type: :model do
       @order_1.cancel
 
       expect(@order_1.status).to eq("Cancelled")
+      expect(@item_order1.status).to eq("unfulfilled")
     end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -36,5 +36,13 @@ describe Order, type: :model do
     it 'total_quantity' do
       expect(@order_1.total_quantity).to eq(5)
     end
+
+    it 'cancel' do
+      expect(@order_1.status).to eq("Pending")
+
+      @order_1.cancel
+
+      expect(@order_1.status).to eq("Cancelled")
+    end
   end
 end


### PR DESCRIPTION
- User can cancel an order and two default statuses change (unfulfilled and cancelled) when user clicks on cancel

- Two migrations
       - Add default status (unfulfilled) to item_orders
       - Add default status (pending) to orders

- When a user cancels an order, the quantity they bought is added to the inventory. However, there's not a method (yet) that reduces the quantity